### PR TITLE
Export Chart along in web component

### DIFF
--- a/webcomponent/chart.js
+++ b/webcomponent/chart.js
@@ -67,4 +67,9 @@ class ChartjsChart extends window.HTMLElement {
   }
 }
 
-window.customElements.define('chart-component', ChartjsChart)
+function registerChartComponent() {
+  window.customElements.define('chart-component', ChartjsChart)
+}
+
+registerChartComponent()
+export { Chart, registerChartComponent }


### PR DESCRIPTION
This PR updates the web component to additionally export the Chart class along. By doing this, Chart.js can now be customised when importing the web component.

As an example:

```js
import { Chart } from '@indicatrix/elm-chartjs-webcomponent/webcomponent/chart';
import { Elm } from './Main.elm';

const backgroundPlugin = {
  id: 'addBackgroundToChart',
  beforeDraw(chart) {
    const { ctx } = chart;
    ctx.fillStyle = 'white';
    ctx.fillRect(0, 0, chart.width, chart.height);
  },
};
Chart.register(backgroundPlugin);
```

Additionally, we export the `registerChartComponent` function - this should automatically be called when importing the module, but JS build systems are terrifying things so I'd rather be safe and export it just in case somebody ever needs it